### PR TITLE
change VERSION variable from maven to github tag (probably)

### DIFF
--- a/webpack/environment.js
+++ b/webpack/environment.js
@@ -1,6 +1,6 @@
 module.exports = {
   // APP_VERSION is passed as an environment variable from the Gradle / Maven build tasks.
-  VERSION: process.env.hasOwnProperty('APP_VERSION') ? process.env.APP_VERSION : 'DEV',
+  VERSION: process.env.hasOwnProperty('GITHUB_REF_NAME') ? process.env.GITHUB_REF_NAME : 'DEV',
   // The root URL for API calls, ending with a '/' - for example: `"https://www.jhipster.tech:8081/myservice/"`.
   // If this URL is left empty (""), then it will be relative to the current context.
   // If you use an API server, in `prod` mode, you will need to enable CORS


### PR DESCRIPTION
It will change a version tag in a header next to the logo to the one which is presented in a release as a tag.

Or at least I hope so, we will see during next deploy.